### PR TITLE
fix: raise connection error when auth fails

### DIFF
--- a/lib/kafka/sasl/awsmskiam.rb
+++ b/lib/kafka/sasl/awsmskiam.rb
@@ -42,7 +42,7 @@ module Kafka
 
           raise Kafka::Error, "SASL AWS_MSK_IAM authentication failed: unknown error" unless @server_first_message
         rescue Errno::ETIMEDOUT, EOFError => e
-          raise Kafka::Error, "SASL AWS_MSK_IAM authentication failed: #{e.message}"
+          raise Kafka::ConnectionError, "SASL AWS_MSK_IAM authentication failed: #{e.message}"
         end
 
         @logger.debug "SASL #{AWS_MSK_IAM} authentication successful"


### PR DESCRIPTION
Raise connection error when auth fails due to timeout or EOF. This will force a retry and re-connect.

Connection error is rescued here https://github.com/scriptdash/ruby-kafka/blob/master/lib/kafka/produce_operation.rb#L135
Messages are not cleared because it is raised before we handle the response https://github.com/scriptdash/ruby-kafka/blob/master/lib/kafka/produce_operation.rb#L200
Buffer size is not zero so the produce is retried https://github.com/scriptdash/ruby-kafka/blob/master/lib/kafka/producer.rb#L419